### PR TITLE
feat(docker): dockerização da web interface

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -36,7 +36,23 @@ services:
       interval: 30s
       timeout: 20s
       retries: 3
-
+  frontend:
+    build:
+      context: ./web/client
+    container_name: ehfake_frontend
+    ports:
+      - "5173:5173"
+    depends_on:
+      - backend
+  backend:
+    build:
+      context: ./web/server
+    container_name: ehfake_backend
+    ports:
+      - "8000:8000"
+    depends_on:
+      - minio
+      
 volumes:
   pgdata:
     driver: local

--- a/web/client/Dockerfile
+++ b/web/client/Dockerfile
@@ -1,8 +1,13 @@
-FROM node:18-alpine as builder
+FROM node:24.3.0-alpine
 
 WORKDIR /web
 
-COPY package.json
+RUN npm install -g pnpm
+
+COPY package.json pnpm-lock.yaml ./
+
+ENV PNPM_HOME=/pnpm-test/.pnpm
+ENV PATH=$PATH:$PNPM_HOME
 
 RUN pnpm install 
 
@@ -10,4 +15,4 @@ COPY . .
 
 EXPOSE 5173
 
-CMD ["pnpm", "run", "dev"]
+CMD ["pnpm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "5173"]

--- a/web/client/Dockerfile
+++ b/web/client/Dockerfile
@@ -1,17 +1,31 @@
-FROM node:24.3.0-alpine
-
-WORKDIR /web
+FROM node:24.3.0-alpine AS builder
 
 RUN npm install -g pnpm
 
-COPY package.json pnpm-lock.yaml ./
+WORKDIR /web
 
-ENV PNPM_HOME=/pnpm-test/.pnpm
+ENV PNPM_HOME=/pnpm
 ENV PATH=$PATH:$PNPM_HOME
 
-RUN pnpm install 
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+FROM node:24.3.0-alpine AS runtime
+
+RUN npm install -g pnpm
+
+WORKDIR /web
+
+ENV PNPM_HOME=/pnpm
+ENV PATH=$PATH:$PNPM_HOME
+
+COPY --from=builder /web/node_modules ./node_modules
+COPY --from=builder /web/package.json /web/pnpm-lock.yaml ./
 
 COPY . .
+
+RUN chown -R node:node /web
+USER node
 
 EXPOSE 5173
 

--- a/web/client/Dockerfile
+++ b/web/client/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:18-alpine as builder
+
+WORKDIR /web
+
+COPY package.json
+
+RUN pnpm install 
+
+COPY . .
+
+EXPOSE 5173
+
+CMD ["pnpm", "run", "dev"]

--- a/web/client/vite.config.ts
+++ b/web/client/vite.config.ts
@@ -3,7 +3,6 @@ import react from "@vitejs/plugin-react";
 import path from "node:path";
 import tailwindcss from "@tailwindcss/vite";
 
-// https://vite.dev/config/
 export default defineConfig({
 	plugins: [react(), tailwindcss()],
 	resolve: {
@@ -11,4 +10,9 @@ export default defineConfig({
 			"@": path.resolve(__dirname, "./src"),
 		},
 	},
+	server: {
+    host: '0.0.0.0',
+    port: 5173,
+    strictPort: true
+  	},
 });

--- a/web/server/Dockerfile
+++ b/web/server/Dockerfile
@@ -1,19 +1,36 @@
-FROM docker.io/python:3.12.3
+FROM docker.io/python:3.12.3 AS builder
 
-WORKDIR /backend
-
-RUN pip install --user pipenv
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN python -m venv /opt/venv
-
 ENV PATH="/opt/venv/bin:$PATH"
 
 COPY requirements.txt ./
 
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt
+
+FROM docker.io/python:3.12.3-slim AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd -r appuser && useradd -r -g appuser appuser
+
+COPY --from=builder /opt/venv /opt/venv
+
+ENV PATH="/opt/venv/bin:$PATH"
+
+WORKDIR /backend
 
 COPY . .
 
+RUN chown -R appuser:appuser /backend
+
+USER appuser
+
 EXPOSE 8000
 
-CMD ["uvicorn", "main:app", "--reload", "--host", "0.0.0.0"] 
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/web/server/Dockerfile
+++ b/web/server/Dockerfile
@@ -1,0 +1,19 @@
+FROM docker.io/python:3.12.3
+
+WORKDIR /backend
+
+RUN pip install --user pipenv
+
+RUN python -m venv /opt/venv
+
+ENV PATH="/opt/venv/bin:$PATH"
+
+COPY requirements.txt ./
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "main:app", "--reload", "--host", "0.0.0.0"] 

--- a/web/server/main.py
+++ b/web/server/main.py
@@ -18,7 +18,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-MINIO_ENDPOINT = os.getenv('MINIO_ENDPOINT', 'localhost:9000')
+MINIO_ENDPOINT = os.getenv('MINIO_ENDPOINT', 'minio:9000')
 MINIO_ACCESS_KEY = os.getenv('MINIO_ACCESS_KEY', 'minioadmin')
 MINIO_SECRET_KEY = os.getenv('MINIO_SECRET_KEY', 'minioadmin')
 MINIO_BUCKET = os.getenv('MINIO_BUCKET', 'scraped-articles')


### PR DESCRIPTION
## Dockerização da interface web

Esse PR adiciona a dockerização do backend e frontend da interface web para os usuários conseguirem ler os json armazenados no minio. E adição dos containers criados no docker compose para serem executados no `make start`.

## 🧪 Como Testar
1.  Subir o serviço
  ```bash
  make start
  ```
  
2. Inicializar o banco:
  ```bash
  make init_db
  ```
  
3. Aplicar migrações:
  ```bash
  make migrate_db
  ```

  4. Rodar spider para coletar URLs de notícias:
  ```bash
  make crawl_aliadosBrasil
  make crawl_maisgoias
  ```

  5. Rodar scraper para processar e salvar as notícias no MinIO:
  ```bash
  docker compose exec scraper python scrape_no_openai.py --platform aliadosbrasiloficial.com.br
  docker compose exec scraper python scrape_no_openai.py --platform maisgoias.com.br
  ```