### PR TITLE
Docs: Atualizando troubleshooting readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,8 +246,7 @@ make prune
 docker compose exec --user root scraper bash
 source /usr/src/.venv/bin/activate
 playwright install --with-deps firefox
-python scrape_no_openai.py --platform metropoles.com
-
+python scrape_no_openai.py --platform metropoles.com # Extração do Metrópoles
 ```
 
 ### 💡 Exemplos Práticos

--- a/README.md
+++ b/README.md
@@ -240,6 +240,16 @@ docker compose down --remove-orphans
 make prune
 ```
 
+**5. Erro "BrowserType.launch_persistent_context: Executable doesn't exist at /project/.cache/ms-playwright/firefox-1475/firefox/"**
+```bash
+# Se o Playwright não encontrar os navegadores ou ocorrer erro de permissão, instale os navegadores e rode o scraper manualmente dentro do contêiner:
+docker compose exec --user root scraper bash
+source /usr/src/.venv/bin/activate
+playwright install --with-deps firefox
+python scrape_no_openai.py --platform metropoles.com
+
+```
+
 ### 💡 Exemplos Práticos
 
 **Coleta rápida de um portal específico:**


### PR DESCRIPTION
# Descrição

## O que foi alterado
Adicionado um novo fluxo de troubleshooting no README.md e documentado na issue para resolver o problema de permissão e instalação dos navegadores do Playwright dentro do container scraper. Inclui instruções para entrar no container, ativar o ambiente virtual e instalar os browsers antes de rodar o scraper.
O erro `"Executable doesn't exist"` ocorria porque os binários do navegador não estavam acessíveis ao usuário `scraper`. Tentativas anteriores de instalar os navegadores durante o build ou via volumes não funcionaram. A alteração garante que novos contribuidores consigam rodar o scraping sem problemas de permissão, melhorando o onboarding e a confiabilidade do projeto.


## 🗂️ Tipo de Mudança
- [ ] 🐞 Correção de bug (*fix*)
- [ ] ✨ Nova funcionalidade (*feat*)
- [ ] ♻️ Refatoração (*refactor/improve*)
- [x] 📝 Documentação (*docs*)
- [ ] 🚀 Performance (*perf*)
- [ ] 🧪 Testes (*test*)
- [ ] ⚙️ Build/CI (*build/ci/cd/static*)

## 📌 Checklist
- [x] Mensagem de commit segue o padrão **Conventional Commits**  
- [x] Nome da branch segue a **Política de Branches Git Flow**  
- [ ] Testes adicionados/atualizados  
- [x] Documentação atualizada (README / Storybook / Swagger / MkDocs)  
- [ ] Pipeline CI/CD aprovado  
- [ ] Sem dependências pendentes

## 🔗 Issues Relacionadas
Closes [#22](https://github.com/EH-FAKE/check-up/issues/22)

## 🧪 Como Testar
Não se aplica.

## 📷 Evidências
Screenshots, GIFs ou logs (se aplicável).

## 📃 Notas Adicionais
Observações para revisores ou deploy.